### PR TITLE
Expand IPs  

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ Takes a list of domain names and in-scope IP addresses as input and returns the 
 ```bash
 inscope.sh domains.txt scope.txt
 ```
+
+### Dependencies
+
+* [Nmap](https://nmap.org/book/inst-linux.html)
+* [anew](https://github.com/tomnomnom/anew)

--- a/inscope.sh
+++ b/inscope.sh
@@ -1,10 +1,14 @@
-if [[ -z $1 ]] || [[ -z $2 ]]
+#!/bin/bash
+
+nmap -sL -n -iL ips.txt | awk '/Nmap scan report/{print $NF}' >> all_ips_scope.txt
+
+if [[ -z $1 ]]
 then
-	echo "Usage: inscope.sh [DOMAIN_NAMES] [IN_SCOPE_IPS]"
+	echo "Usage: inscope.sh [DOMAIN_NAMES]"
 	exit
 fi
 DOMAINS=$(cat $1)
-SCOPE=$2
+SCOPE=all_ips_scope.txt
 for i in $DOMAINS
 do
 	IP=$(dig +short $i)

--- a/inscope.sh
+++ b/inscope.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-nmap -sL -n -iL ips.txt | awk '/Nmap scan report/{print $NF}' >> all_ips_scope.txt
-
-if [[ -z $1 ]]
+if [[ -z $1 ]] || [[ -z $2 ]]
 then
-	echo "Usage: inscope.sh [DOMAIN_NAMES]"
+	echo "Usage: inscope.sh [DOMAIN_NAMES] [Synack-Scope-txt-file.txt]"
 	exit
 fi
+nmap -sL -n -iL $2 | awk '/Nmap scan report/{print $NF}' >> all_ips_scope.txt
 DOMAINS=$(cat $1)
 SCOPE=all_ips_scope.txt
 for i in $DOMAINS
@@ -14,6 +13,6 @@ do
 	IP=$(dig +short $i)
 	if [[ ! -z $IP ]] && grep -q "$IP" $SCOPE
 	then
-		echo $i
+		echo $i | tee -a inscope_domains.txt
 	fi
 done

--- a/inscope.sh
+++ b/inscope.sh
@@ -13,6 +13,6 @@ do
 	IP=$(dig +short $i)
 	if [[ ! -z $IP ]] && grep -q "$IP" $SCOPE
 	then
-		echo $i | tee -a inscope_domains.txt
+		echo $i | anew inscope_domains.txt
 	fi
 done


### PR DESCRIPTION
* Spits out IP List from Synack's downloadable CIDR list.
* Saves only unique entries to a file. (Used anew to smoothly add only new unique entries in case of more IPs being added to scope.)
* Updated Readme accordingly  